### PR TITLE
Subdomain fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ If both the zones and the certificates are to be created in the calling account,
 
 `var.parent_zone` is the zone for which you're asking subdomain certificates for. By default, it is included in the certificates domains. This behaviour can be changed by setting `var.parent_zone_in_domains` to `false`.
 
-`var.main_subdomain` is used for the `domain` setting for the certificate. The first element of the subdomain list will be used if this is omitted.
+`var.main_subdomain` is used for the `domain` setting for the certificate. The first element of the subdomain list will be used if this is omitted. Will have no effect if `var.parent_zone_in_domains` evaluates to true (in which case `var.parent_zone` is used as the main domain).
 
-`var.subdomains` is a map of lists for historical reasons. It used to be that the module would create multiple certificates for each entry. Now however, you can treat both the key and its list all as subdomains of `var.parent_zone`. If you provide `var.subdomains`, you must give an empty list if there are no aliases, as in the example. There will be a breaking change in a future release that replaces this with a simple set.
+`var.subdomains` is a list of additional aliases to add to the certificate.
 
 For example:
 
@@ -34,14 +34,14 @@ For example:
 
 # Will give a certificate valid for bar.com and foo.bar.com
   parent_zone = "bar.com"
-  subdomains  = { "foo" = [] }
+  subdomains  = [ "foo" ]
 
-# Will give a certificate valid for bar.com, foo.bar.com, and cow.bar.com
+# Will give a certificate valid for bar.com, foo.bar.com, and moo.bar.com
   parent_zone = "bar.com"
-  subdomains  = { "foo" = ["cow"] }
+  subdomains  = [ "foo", "moo" ]
 
 # Will give a certificate valid for foo.bar.com, and cow.bar.com
   parent_zone = "bar.com"
-  subdomains = { "foo" = ["cow"] }
+  subdomains = [ "foo", "mow"]
   parent_zone_in_domains = false
 ```

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,22 +3,12 @@ output "all" {
 }
 
 output "certificate_arn" {
-  value = one([for this_domain in aws_acm_certificate_validation.this : this_domain.certificate_arn])
+  value = aws_acm_certificate_validation.this.certificate_arn
 }
 
-output "certificate_arns" {
-  value = [for this_domain in aws_acm_certificate_validation.this : this_domain.certificate_arn]
-}
-
-output "subdomains_and_aliases" {
-  description = "Flattened list of all subdomains and their aliases"
-
-  value = local.fqdn_top_level_aliases
-}
-
-output "parent_and_subdomains" {
-  description = "Parent zones mapped to lists of all subdomains"
-  value       = local.parent_and_subdomains
+output "main_domain" {
+  description = "Main domain for certificate"
+  value       = local.domain_name
 }
 
 output "all_subdomains" {
@@ -28,10 +18,5 @@ output "all_subdomains" {
 
 output "certificate_domains" {
   description = "Domains for which we'll create a certificate"
-  value       = local.certificate_domains
-}
-
-output "fqdn_subdomains" {
-  description = "Just the subdomains"
   value       = local.fqdn_subdomains
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,17 @@ variable "parent_zone" {
   type        = string
 }
 
-variable "subdomains" {
-  description = "Map of subdomains and their aliases. Aliases list is required, though it can be an empty list"
-  type        = map(list(string))
+variable "main_subdomain" {
+  description = "Main subdomain to give the certificate. Defaults to the first element in the subdomains. This default is probably undesirable due to the fact that order can not be maintained when adding new subdomains"
+  type        = string
+  default     = null
+}
 
-  default = {}
+variable "subdomains" {
+  description = "List of additional subdomains to be added the SAN"
+  type        = list(string)
+
+  default = []
 }
 
 # FIXME: This should be a merge of it's own tags module
@@ -19,10 +25,4 @@ variable "parent_zone_in_domains" {
   description = "Whether to include var.parent_zone in the list of domains for the certificate"
   type        = bool
   default     = true
-}
-
-variable "main_subdomain" {
-  description = "Main subdomain to give the certificate. Defaults to the first element in the subdomains. This default is probably undesirable due to the fact that order can not be maintained when adding new subdomains"
-  type        = string
-  default     = null
 }


### PR DESCRIPTION
BREAKING CHANGE: The way SANs and the main domain are handled has been completely revamped. This breaks the old way of providing subdomains (as a map of lists), and the way in which the main domain was set. None of this worked correctly before, and the ways in which subdomains and the main domain is handled fixes everything.

- New var.main_subdomain added
- var.subdomains is now a list
- var.parent_zone will now be used as the "main subdomain" when neither var.subdomains or var.main_subdomain are provided
- Only a single certificate will be generated per instance of the module

See the examples for updated usage.